### PR TITLE
fix: users(ro) can still write

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,7 +114,9 @@ EOH
           users=$(echo "$users" |tr "," " ")
           echo -n "$users "
           echo "valid users = $users" >>"$CONFIG_FILE"
-          echo "write list = $users" >>"$CONFIG_FILE"
+          if [[ "rw" = "$readwrite" ]] ; then
+            echo "write list = $users" >>"$CONFIG_FILE"
+          fi
         fi
         echo "DONE"
         ;;


### PR DESCRIPTION
Hi deftwork,
I'm deploying a smb server. I find it doesn't work when the ro permission is given.  #2  has the same problem. 