### PR TITLE
features: add ability to hide shares and disable `socket options`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,12 +51,19 @@ Container will be configured as samba sharing server and it just needs:
 
 - add a share that is accessible as 'name', exposing contents of 'path' directory. 'show' or 'hidden' controls whether this 'name' is browsable or not. this share also has read+write (rw) or read-only (ro)access control for specified logins user1, user2, .., userN
 
+### Environmental Variable(s)
+- `DISABLE_SOCKET_OPTIONS`, by default, the `[global]` section of the container's `smb.conf` will contain the line:
+   ```
+   socket options = TCP_NODELAY SO_RCVBUF=8192 SO_SNDBUF=8192
+   ```
+   This may cause slow transfer for some use cases. In order to disable this line, add `-e DISABLE_SOCKET_OPTIONS=yes` to `docker run`.
+
 ### Serve 
 
 Start a samba fileshare.
 
 ``` sh
-docker run -d -p 445:445 \
+docker run -d -p 139:139 -p 445:445 \
   -- hostname any-host-name \ # Optional
   -e TZ=Europe/Madrid \ # Optional
   -v /any/path:/share/data \ # Replace /any/path with some path in your system owned by a real user from your host filesystem

--- a/Readme.md
+++ b/Readme.md
@@ -47,9 +47,9 @@ Container will be configured as samba sharing server and it just needs:
 - usergroup (wich user must belong) p.e. alice
 - password (The password may be different from the user's actual password from your host filesystem)
 
--s name:path:rw:user1[,user2[,userN]]
+-s name:path:show:rw:user1[,user2[,userN]]
 
-- add share, that is visible as 'name', exposing contents of 'path' directory for read+write (rw) or read-only (ro) access for specified logins user1, user2, .., userN 
+- add a share that is accessible as 'name', exposing contents of 'path' directory. 'show' or 'hidden' controls whether this 'name' is browsable or not. this share also has read+write (rw) or read-only (ro)access control for specified logins user1, user2, .., userN
 
 ### Serve 
 
@@ -64,10 +64,10 @@ docker run -d -p 445:445 \
   -u "1000:1000:alice:alice:put-any-password-here" \ # At least the first user must match (password can be different) with a real user from your host filesystem
   -u "1001:1001:bob:bob:secret" \
   -u "1002:1002:guest:guest:guest" \
-  -s "Backup directory:/share/backups:rw:alice,bob" \ 
-  -s "Alice (private):/share/data/alice:rw:alice" \
-  -s "Bob (private):/share/data/bob:rw:bob" \
-  -s "Documents (readonly):/share/data/documents:ro:guest,alice,bob"
+  -s "Backup directory:/share/backups:show:rw:alice,bob" \ 
+  -s "Alice (private):/share/data/alice:show:rw:alice" \
+  -s "Bob (private):/share/data/bob:hidden:rw:bob" \ # Bob's private share does not show up when user is browsing the shares
+  -s "Documents (readonly):/share/data/documents:show:ro:guest,alice,bob"
 ``` 
 
 This is my real usage command:
@@ -76,7 +76,7 @@ This is my real usage command:
 docker run -d -p 445:445 -e TZ=Europe/Madrid \
     -v /home/pirate/docker/makefile:/share/folder elswork/samba \
     -u "1000:1000:pirate:pirate:put-any-password-here" \
-    -s "SmbShare:/share/folder:rw:pirate"
+    -s "SmbShare:/share/folder:show:rw:pirate"
 ```
 or this if the user that owns the path to be shared match with the user that raise up the container:
 
@@ -84,7 +84,7 @@ or this if the user that owns the path to be shared match with the user that rai
 docker run -d -p 445:445 --hostname $HOSTNAME -e TZ=Europe/Madrid \
     -v /home/pirate/docker/makefile:/share/folder elswork/samba \
     -u "$(id -u):$(id -g):$(id -un):$(id -gn):put-any-password-here" \
-    -s "SmbShare:/share/folder:rw:$(id -un)"
+    -s "SmbShare:/share/folder:show:rw:$(id -un)"
 ```
 
 On Windows point your filebrowser to `\\host-ip\` to preview site.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,12 @@
 CONFIG_FILE="/etc/samba/smb.conf"
 FIRSTTIME=true
 
+if [[ -z "$DISABLE_SOCKET_OPTIONS" ]] ; then
+  COMMENT_IT=""
+else
+  COMMENT_IT="# "
+fi
+
 hostname=`hostname`
 set -e
 cat >"$CONFIG_FILE" <<EOT
@@ -24,8 +30,7 @@ disable spoolss = yes
 guest account = nobody
 max log size = 50
 map to guest = bad user
-# socket options caused slow performance on my network
-# socket options = TCP_NODELAY SO_RCVBUF=8192 SO_SNDBUF=8192
+${COMMENT_IT}socket options = TCP_NODELAY SO_RCVBUF=8192 SO_SNDBUF=8192
 local master = no
 dns proxy = no
 EOT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,7 +76,7 @@ docker run -d -p 445:445 \\
   -u "1002:1002:guest:guest:guest" \\
   -s "Backup directory:/share/backups:show:rw:alice,bob" \\ 
   -s "Alice (private):/share/data/alice:show:rw:alice" \\
-  -s "Bob (private):/share/data/bob:noshow:rw:bob" \\ # Bob's private share does not show up when user is browsing the shares
+  -s "Bob (private):/share/data/bob:hidden:rw:bob" \\ # Bob's private share does not show up when user is browsing the shares
   -s "Documents (readonly):/share/data/documents:show:ro:guest,alice,bob"
 
 EOH

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,8 +97,10 @@ EOH
         
         if [[ "show" = "$show" ]] ; then
           echo -n "browsable "
+ #         echo "browseable = yes" >>"$CONFIG_FILE"
         else
-          echo -n "not-browseable"
+          echo -n "not-browseable "
+          echo "browseable = no" >>"$CONFIG_FILE"
         fi
         
         echo -n "read"
@@ -113,7 +115,10 @@ EOH
         fi
         if [[ -z "$users" ]] ; then
           echo -n "for guests: "
-          echo "browseable = yes" >>"$CONFIG_FILE"
+          if [[ "show" = "$show" ]] ; then
+            echo -n "(guest-browesable): "
+            echo "browseable = yes" >>"$CONFIG_FILE"
+          fi
           echo "guest ok = yes" >>"$CONFIG_FILE"
           echo "public = yes" >>"$CONFIG_FILE"
         else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -96,7 +96,7 @@ EOH
         echo "path = \"$sharepath\"" >>"$CONFIG_FILE"
         
         if [[ "show" = "$show" ]] ; then
-          echo -n "browsable "
+          echo -n "browseable "
  #         echo "browseable = yes" >>"$CONFIG_FILE"
         else
           echo -n "not-browseable "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,10 +56,12 @@ Container will be configured as samba sharing server and it just needs:
                                                 add a usergroup (wich user must belong) p.e. alice
                                                 protected by 'password' (The password may be different from the user's actual password from your host filesystem)
 
- -s name:path:rw:user1[,user2[,userN]]
-                              add share, that is visible as 'name', exposing
-                              contents of 'path' directory for read+write (rw)
-                              or read-only (ro) access for specified logins
+ -s name:path:show:rw:user1[,user2[,userN]]
+                              add a share that is accessible as 'name', exposing
+                              contents of 'path' directory. 'show' or 'noshow'
+                              controls whether this 'name' is browsable or not.
+                              this share also has read+write (rw) or read-only (ro)
+                              access control for specified logins
                               user1, user2, .., userN
 
 To adjust the global samba options, create a volume mapping to /config
@@ -72,10 +74,10 @@ docker run -d -p 445:445 \\
   -u "1000:1000:alice:alice:put-any-password-here" \\ # At least the first user must match (password can be different) with a real user from your host filesystem
   -u "1001:1001:bob:bob:secret" \\
   -u "1002:1002:guest:guest:guest" \\
-  -s "Backup directory:/share/backups:rw:alice,bob" \\ 
-  -s "Alice (private):/share/data/alice:rw:alice" \\
-  -s "Bob (private):/share/data/bob:rw:bob" \\
-  -s "Documents (readonly):/share/data/documents:ro:guest,alice,bob"
+  -s "Backup directory:/share/backups:show:rw:alice,bob" \\ 
+  -s "Alice (private):/share/data/alice:show:rw:alice" \\
+  -s "Bob (private):/share/data/bob:noshow:rw:bob" \\ # Bob's private share does not show up when user is browsing the shares
+  -s "Documents (readonly):/share/data/documents:show:ro:guest,alice,bob"
 
 EOH
         exit 1
@@ -103,7 +105,7 @@ EOH
         
         if [[ "show" = "$show" ]] ; then
           echo -n "browseable "
- #         echo "browseable = yes" >>"$CONFIG_FILE"
+          # echo "browseable = yes" >>"$CONFIG_FILE" # browseable = yes is the default behavior
         else
           echo -n "not-browseable "
           echo "browseable = no" >>"$CONFIG_FILE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,11 +89,18 @@ EOH
         ;;
       s)
         echo -n "Add share "
-        IFS=: read sharename sharepath readwrite users <<<"$OPTARG"
+        IFS=: read sharename sharepath show readwrite users <<<"$OPTARG"
         echo -n "'$sharename' "
         echo "[$sharename]" >>"$CONFIG_FILE"
         echo -n "path '$sharepath' "
         echo "path = \"$sharepath\"" >>"$CONFIG_FILE"
+        
+        if [[ "show" = "$show" ]] ; then
+          echo -n "browsable "
+        else
+          echo -n "not-browseable"
+        fi
+        
         echo -n "read"
         if [[ "rw" = "$readwrite" ]] ; then
           echo -n "+write "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,8 @@ disable spoolss = yes
 guest account = nobody
 max log size = 50
 map to guest = bad user
-socket options = TCP_NODELAY SO_RCVBUF=8192 SO_SNDBUF=8192
+# socket options caused slow performance on my network
+# socket options = TCP_NODELAY SO_RCVBUF=8192 SO_SNDBUF=8192
 local master = no
 dns proxy = no
 EOT


### PR DESCRIPTION
I added two features:
1. ability to make a share browsable or not by the `show` flag in `-s` parameter  
this changes the syntax for `-s` from
  ```
  -s name:path:rw:user1[,user2[,userN]]
  ```
  to
  ```
  -s name:path:show:rw:user1[,user2[,userN]]
  ```
  if `show` is any other word (like `hidden`), the share will not be browsable.  

2. ability to remove `socket options` line from `[global]` section of `smb.conf`. having it there caused slow transfer for my use case.