### PR TITLE
No password in logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ LABEL mantainer="Eloy Lopez <elswork@gmail.com>" \
 
 RUN apk update && apk upgrade && apk add --no-cache bash samba-common-tools samba tzdata && rm -rf /var/cache/apk/*
 
+RUN sed -i '/\[homes\]/,/writable/ s/^/;/' /etc/samba/smb.conf
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod u+x /entrypoint.sh
 

--- a/Readme.md
+++ b/Readme.md
@@ -48,9 +48,9 @@ Container will be configured as samba sharing server and it just needs:
 - usergroup (the one to whom user belongs) p.e. alice
 - password (The password may be different from the user's actual password from your host filesystem)
 
--s name:path:rw:user1[,user2[,userN]]
+-s name:path:rw:user1[,user2[,userN]][:recycle]
 
-- add share, that is visible as 'name', exposing contents of 'path' directory for read+write (rw) or read-only (ro) access for specified logins user1, user2, .., userN
+- add share, that is visible as 'name', exposing contents of 'path' directory for read+write (rw) or read-only (ro) access for specified logins user1, user2, .., userN ; Add optional recycle arg to activate recycle with value as dirname
 
 ### Serve
 
@@ -65,8 +65,8 @@ docker run -d -p 139:139 -p 445:445 \
   -u "1000:1000:alice:alice:put-any-password-here" \ # At least the first user must match (password can be different) with a real user from your host filesystem
   -u "1001:1001:bob:bob:secret" \
   -u "1002:1002:guest:guest:guest" \
-  -s "Backup directory:/share/backups:rw:alice,bob" \ 
-  -s "Alice (private):/share/data/alice:rw:alice" \
+  -s "Backup directory:/share/backups:rw:alice,bob" \
+  -s "Alice (private):/share/data/alice:rw:alice:.recycle-bin" \
   -s "Bob (private):/share/data/bob:rw:bob" \
   -s "Documents (readonly):/share/data/documents:ro:guest,alice,bob"
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,11 +52,12 @@ Container will be configured as samba sharing server and it just needs:
                                                 add a usergroup (wich user must belong) p.e. alice
                                                 protected by 'password' (The password may be different from the user's actual password from your host filesystem)
 
- -s name:path:rw:user1[,user2[,userN]]
+ -s name:path:rw:user1[,user2[,userN]][:recycle]
                               add share, that is visible as 'name', exposing
                               contents of 'path' directory for read+write (rw)
                               or read-only (ro) access for specified logins
-                              user1, user2, .., userN
+                              user1, user2, .., userN ; Add optional recycle
+                              arg to activate recycle with value as dirname
 
 To adjust the global samba options, create a volume mapping to /config
 
@@ -68,8 +69,8 @@ docker run -d -p 445:445 \\
   -u "1000:1000:alice:alice:put-any-password-here" \\ # At least the first user must match (password can be different) with a real user from your host filesystem
   -u "1001:1001:bob:bob:secret" \\
   -u "1002:1002:guest:guest:guest" \\
-  -s "Backup directory:/share/backups:rw:alice,bob" \\ 
-  -s "Alice (private):/share/data/alice:rw:alice" \\
+  -s "Backup directory:/share/backups:rw:alice,bob" \\
+  -s "Alice (private):/share/data/alice:rw:alice:.recycle-bin" \\
   -s "Bob (private):/share/data/bob:rw:bob" \\
   -s "Documents (readonly):/share/data/documents:ro:guest,alice,bob"
 
@@ -91,7 +92,7 @@ EOH
         ;;
       s)
         echo -n "Add share "
-        IFS=: read sharename sharepath readwrite users <<<"$OPTARG"
+        IFS=: read sharename sharepath readwrite users recycle <<<"$OPTARG"
         echo -n "'$sharename' "
         echo "[$sharename]" >>"$CONFIG_FILE"
         echo -n "path '$sharepath' "
@@ -117,6 +118,14 @@ EOH
           echo -n "$users "
           echo "valid users = $users" >>"$CONFIG_FILE"
           echo "write list = $users" >>"$CONFIG_FILE"
+        fi
+        if [[ -n "$recycle" ]] ; then
+          echo -n "with recycle bin '$recycle' "
+          echo "vfs objects = recycle" >>"$CONFIG_FILE"
+          echo "recycle:repository = $recycle" >>"$CONFIG_FILE"
+          echo "recycle:keeptree = yes" >>"$CONFIG_FILE"
+          echo "recycle:versions = yes" >>"$CONFIG_FILE"
+          echo "recycle:directory_mode = 0775" >>"$CONFIG_FILE" # Same than "force directory mode"
         fi
         echo "DONE"
         ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,7 +86,7 @@ EOH
           id -u "$uid" &>/dev/null || id -un "$username" &>/dev/null || adduser -u "$uid" -G "$groupname" "$username" -SHD
           FIRSTTIME=false
         fi
-        echo -n "with password '$password' "
+        echo -n "with password '${password:0:1}***${password: -1}' "
         echo "$password" |tee - |smbpasswd -s -a "$username"
         echo "DONE"
         ;;


### PR DESCRIPTION
Hi,

I don't like to see passwords in the logs, except for debug/verbose (option to add ?). I do a MR to make an alternative to full show or full hide of the password : show the first and the last char of the password. I think the best practice is to no show any char of the password (to avoid to help to find it in a dictionary etc), but for my personal use it's not really a problem.

Regards,