### PR TITLE
Partially hide password in logs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,7 +85,7 @@ EOH
           id -u "$uid" &>/dev/null || id -un "$username" &>/dev/null || adduser -u "$uid" -G "$groupname" "$username" -SHD
           FIRSTTIME=false
         fi
-        echo -n "with password '$password' "
+        echo -n "with password '${password:0:1}***${password: -1}' "
         echo "$password" |tee - |smbpasswd -s -a "$username"
         echo "DONE"
         ;;


### PR DESCRIPTION
Hi,

I don't like to see passwords in the logs, except for debug/verbose (option to add ?). I do a MR to make an alternative to full show or full hide of the password : show the first and the last char of the password. I think the best practice is to no show any char of the password (to avoid to help to find it in a dictionary etc), but for my personal use it's not really a problem.

Regards,