### PR TITLE
Add the -p performance option, which improves cache performance

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,7 @@ Container will be configured as samba sharing server and it just needs:
 - password (The password may be different from the user's actual password from your host filesystem)
 
 -s name:path:rw:user1[,user2[,userN]]
+-p name:path:rw:user1[,user2[,userN]]
 
 - add share, that is visible as 'name', exposing contents of 'path' directory for read+write (rw) or read-only (ro) access for specified logins user1, user2, .., userN
 
@@ -65,7 +66,7 @@ docker run -d -p 139:139 -p 445:445 \
   -u "1002:1002:guest:guest:guest" \
   -s "Backup directory:/share/backups:rw:alice,bob" \ 
   -s "Alice (private):/share/data/alice:rw:alice" \
-  -s "Bob (private):/share/data/bob:rw:bob" \
+  -p "Bob (private):/share/data/bob:rw:bob" \
   -s "Documents (readonly):/share/data/documents:ro:guest,alice,bob"
 ```
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ local master = no
 dns proxy = no
 EOT
 fi
-  while getopts ":u:s:h" opt; do
+  while getopts ":u:s:p:h" opt; do
     case $opt in
       h)
         cat <<EOH
@@ -90,6 +90,41 @@ EOH
         IFS=: read sharename sharepath readwrite users <<<"$OPTARG"
         echo -n "'$sharename' "
         echo "[$sharename]" >>"$CONFIG_FILE"
+        echo -n "path '$sharepath' "
+        echo "path = \"$sharepath\"" >>"$CONFIG_FILE"
+        echo -n "read"
+        if [[ "rw" = "$readwrite" ]] ; then
+          echo -n "+write "
+          echo "read only = no" >>"$CONFIG_FILE"
+          echo "writable = yes" >>"$CONFIG_FILE"
+        else
+          echo -n "-only "
+          echo "read only = yes" >>"$CONFIG_FILE"
+          echo "writable = no" >>"$CONFIG_FILE"
+        fi
+        if [[ -z "$users" ]] ; then
+          echo -n "for guests: "
+          echo "browseable = yes" >>"$CONFIG_FILE"
+          echo "guest ok = yes" >>"$CONFIG_FILE"
+          echo "public = yes" >>"$CONFIG_FILE"
+        else
+          echo -n "for users: "
+          users=$(echo "$users" |tr "," " ")
+          echo -n "$users "
+          echo "valid users = $users" >>"$CONFIG_FILE"
+          echo "write list = $users" >>"$CONFIG_FILE"
+        fi
+        echo "DONE"
+        ;;
+      p)
+        echo -n "Add share async"
+        IFS=: read sharename sharepath readwrite users <<<"$OPTARG"
+        echo -n "'$sharename' "
+        echo "[$sharename]" >>"$CONFIG_FILE"
+        echo "strict sync = no" >> "$CONFIG_FILE"
+        echo "sync always = no" >> "$CONFIG_FILE"
+        echo "aio read size = 1" >> "$CONFIG_FILE"
+        echo "aio write size = 1" >> "$CONFIG_FILE"
         echo -n "path '$sharepath' "
         echo "path = \"$sharepath\"" >>"$CONFIG_FILE"
         echo -n "read"


### PR DESCRIPTION
Using -p instead of -s adds these parameters, which significantly improved the performance of a slow HDD with LVM cache configured.
strict sync = no
sync always = no
aio read size = 1
aio write size = 1
